### PR TITLE
fix: Resource matching problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-la
               stm.Action = this.arrayify(stm.Action)
               stm.Resource = this.arrayify(stm.Resource)
 
-              if (stm.Resource.filter(res => res.startsWith('*')).length === 0) {
+              if (stm.Resource.filter(res => (typeof res) !== 'object' && res.startsWith('*')).length === 0) {
                 if (stm.Action.filter(act => act.startsWith('logs:')).length > 0) {
                   stm.Resource.push({
                     'Fn::Sub': `arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:${settings.logGroupName}:*`

--- a/index.test.js
+++ b/index.test.js
@@ -80,7 +80,11 @@ describe('Given a logGroupName is not set', () => {
                     PolicyDocument: {
                       Statement: [{
                         Action: ['logs:CreateLogGroup', 'logs:CreateLogStream'],
-                        Resource: ['arn:aws:logs:region:account-id:*']
+                        Resource: [
+                          {
+                            'Fn:: Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/checkout-dev*:*:*'
+                          }
+                        ]
                       }]
                     }
                   }]
@@ -130,7 +134,11 @@ describe('Given a logGroupName is not set', () => {
           PolicyDocument: {
             Statement: [{
               Action: ['logs:CreateLogGroup', 'logs:CreateLogStream'],
-              Resource: ['arn:aws:logs:region:account-id:*']
+              Resource: [
+                {
+                  'Fn:: Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/checkout-dev*:*:*'
+                }
+              ]
             }]
           }
         }]
@@ -282,7 +290,11 @@ describe('Given a logGroupName is set and a function is excluded', () => {
                       Statement: [{
                         Effect: 'Allow',
                         Action: ['logs:CreateLogGroup', 'logs:CreateLogStream'],
-                        Resource: ['arn:aws:logs:region:account-id:*']
+                        Resource: [
+                          {
+                            'Fn:: Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/checkout-dev*:*:*'
+                          }
+                        ]
                       }]
                     }
                   }]


### PR DESCRIPTION
Resource array can look like this:

```
Resource: [
          {
            'Fn:: Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/checkout-dev*:*:*'
          }
]
```

OR

```
Resource: ['*']
```

This way each item will be an object not a string, so the res.startsWith('*') will not work in that case. So we have to check if the item is an object or not before using startsWith